### PR TITLE
Fix: make query filter case-insensitive and trimmed

### DIFF
--- a/Components/CountriesList.jsx
+++ b/Components/CountriesList.jsx
@@ -14,14 +14,17 @@ function CountriesContainer({ query }) {
       });
   }, []);
 
+  // Normalize query: trim and lowercase
+  const normalizedQuery = query.trim().toLowerCase();
+
   return CountriesData.length === 0 ? (
     <CountryListShimmer />
   ) : (
     <div className="countries-container">
       {CountriesData.filter(
         (country) =>
-          country.name.common.toLowerCase().includes(query) ||
-          country.region.toLowerCase().includes(query)
+          country.name.common.toLowerCase().includes(normalizedQuery) ||
+          country.region.toLowerCase().includes(normalizedQuery)
       ).map((country) => (
         <CountryCard
           key={country.name.common}


### PR DESCRIPTION
This PR fixes issue #4 by normalizing the query string before filtering countries, ensuring case-insensitive and trimmed search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved country search to be case-insensitive and ignore extra spaces, making it easier to find countries regardless of input formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->